### PR TITLE
Station search: Improve UI fluidity 

### DIFF
--- a/fahrplan2.pro
+++ b/fahrplan2.pro
@@ -1,5 +1,5 @@
 # Define Version
-VERSION = 2.0.31
+VERSION = 2.0.33
 
 # Switch for jolla to separate harbour and openrepo version
 openrepos {
@@ -19,7 +19,7 @@ symbian {
 }
 ubuntu {
     DEFINES += FAHRPLAN_VERSION=\\\"$$VERSION\\\"
-    DEFINES += FAHRPLAN_SETTINGS_NAMESPACE=\\\"com.ubuntu.developer.mzanetti.fahrplan2\\\"
+    DEFINES += FAHRPLAN_SETTINGS_NAMESPACE=\\\"de.michael-stevens.fahrplan2\\\"
 }
 exists("/usr/include/sailfishapp/sailfishapp.h"): {
     DEFINES += FAHRPLAN_VERSION=\\\"$$VERSION\\\"

--- a/qtc_packaging/ubuntu/manifest.json
+++ b/qtc_packaging/ubuntu/manifest.json
@@ -8,8 +8,8 @@
             "desktop": "fahrplan2_ubuntu.desktop"
         }
     },
-    "maintainer": "Michael Zanetti <michael_zanetti@gmx.net>",
-    "name": "com.ubuntu.developer.mzanetti.fahrplan2",
+    "maintainer": "Michael Stevens <mail@michael-stevens.de>",
+    "name": "de.michael-stevens.fahrplan2",
     "title": "Fahrplan",
-    "version": "2.0.31"
+    "version": "2.0.33"
 }

--- a/src/fahrplan.cpp
+++ b/src/fahrplan.cpp
@@ -270,13 +270,11 @@ void Fahrplan::resetStation(StationType type)
 
 void Fahrplan::findStationsByName(const QString &stationName)
 {
-    m_stationSearchResults->setStationsList(StationsList());
     m_parser_manager->getParser()->findStationsByName(stationName);
 }
 
 void Fahrplan::findStationsByCoordinates(qreal longitude, qreal latitude)
 {
-    m_stationSearchResults->setStationsList(StationsList());
     m_parser_manager->getParser()->findStationsByCoordinates(longitude, latitude);
 }
 

--- a/src/parser/parser_mobilebahnde.cpp
+++ b/src/parser/parser_mobilebahnde.cpp
@@ -22,10 +22,10 @@
 ParserMobileBahnDe::ParserMobileBahnDe(QObject *parent) :
     ParserHafasBinary(parent)
 {
-     baseXmlUrl = "https://reiseauskunft.bahn.de/bin/query.exe";
-     baseSTTableUrl = "https://mobile.bahn.de/bin/mobil/bhftafel.exe/en";
+     baseXmlUrl = "https://rabdc.bahn.de/bin/query.exe/dn";
+     baseSTTableUrl = "https://rabdc.bahn.de/bin/mobil/bhftafel.exe/en";
      baseUrl = "https://reiseauskunft.bahn.de/bin/query.exe";
-     baseBinaryUrl = "https://reiseauskunft.bahn.de/bin/query.exe/eox";
+     baseBinaryUrl = "https://reiseauskunft.bahn.de/bin/query.exe/eox"; 
      STTableMode = 1;
 }
 


### PR DESCRIPTION
This simple patch improved the Ui fluidity by not clearing the search result before submitting search to parser.
If the search fails as it is refined that the last sucessful station list is show.